### PR TITLE
enforce consistency in delete_all and requeue_all

### DIFF
--- a/lib/outboxer/web.rb
+++ b/lib/outboxer/web.rb
@@ -343,7 +343,7 @@ module Outboxer
         page: denormalised_params[:page],
         per_page: denormalised_params[:per_page])
 
-      result = Messages.requeue_all(status: denormalised_params[:status])
+      result = Messages.requeue_all(status: denormalised_params[:status], older_than: Time.now.utc)
 
       message_text = result[:requeued_count] == 1 ? 'message' : 'messages'
       flash[:primary] = "#{result[:requeued_count]} #{message_text} have been queued"
@@ -366,7 +366,7 @@ module Outboxer
         page: denormalised_params[:page],
         per_page: denormalised_params[:per_page])
 
-      result = Messages.delete_all(status: denormalised_params[:status])
+      result = Messages.delete_all(status: denormalised_params[:status], older_than: Time.now.utc)
 
       message_text = result[:deleted_count] == 1 ? 'message' : 'messages'
       flash[:primary] = "#{result[:deleted_count]} #{message_text} have been deleted"


### PR DESCRIPTION
pass older_than so that live running system does not delete messages created after or when the action was run

closes #121 