### PR TITLE
Change order of CLI options

### DIFF
--- a/lib/outboxer/publisher.rb
+++ b/lib/outboxer/publisher.rb
@@ -15,10 +15,6 @@ module Outboxer
       parser = ::OptionParser.new do |opts|
         opts.banner = "Usage: outboxer_publisher [options]"
 
-        opts.on("-C", "--config PATH", "Path to YAML config file") do |v|
-          options[:config] = v
-        end
-
         opts.on("-e", "--environment ENV", "Application environment") do |v|
           options[:environment] = v
         end
@@ -43,10 +39,6 @@ module Outboxer
           options[:heartbeat_interval] = v
         end
 
-        opts.on("-l", "--log-level LEVEL", Integer, "Log level") do |v|
-          options[:log_level] = v
-        end
-
         opts.on("-s", "--sweep-interval SECS", Float, "Sweep interval in seconds") do |v|
           options[:sweep_interval] = v
         end
@@ -57,6 +49,14 @@ module Outboxer
 
         opts.on("-w", "--sweep-batch-size SIZE", Integer, "Sweep batch size") do |v|
           options[:sweep_batch_size] = v
+        end
+
+        opts.on("-l", "--log-level LEVEL", Integer, "Log level") do |v|
+          options[:log_level] = v
+        end
+
+        opts.on("-C", "--config PATH", "Path to YAML config file") do |v|
+          options[:config] = v
         end
 
         opts.on("-V", "--version", "Print version and exit") do


### PR DESCRIPTION
```
bin/outboxer_publisher -h
Usage: outboxer_publisher [options]
    -e, --environment ENV            Application environment
    -b, --buffer-size SIZE           Buffer size
    -c, --concurrency SIZE           Concurrency
    -t, --tick-interval SECS         Tick interval in seconds
    -p, --poll-interval SECS         Poll interval in seconds
    -a, --heartbeat-interval SECS    Heartbeat interval in seconds
    -s, --sweep-interval SECS        Sweep interval in seconds
    -r, --sweep-retention SECS       Sweep retention in seconds
    -w, --sweep-batch-size SIZE      Sweep batch size
    -l, --log-level LEVEL            Log level
    -C, --config PATH                Path to YAML config file
    -V, --version                    Print version and exit
    -h, --help                       Show this help message
```

Based on sidekiq

```
bin/sidekiq -h
2025-06-15T06:20:35.331Z pid=49709 tid=17y9 INFO: sidekiq [options]
    -c, --concurrency INT            processor threads to use
    -e, --environment ENV            Application environment
    -g, --tag TAG                    Process tag for procline
    -q, --queue QUEUE[,WEIGHT]       Queues to process with optional weights
    -r, --require [PATH|DIR]         Location of Rails application with jobs or file to require
    -t, --timeout NUM                Shutdown timeout
    -v, --verbose                    Print more verbose output
    -C, --config PATH                path to YAML config file
    -V, --version                    Print version and exit
    -h, --help                       Show help
```